### PR TITLE
Adds channel point reward mutual exclusion support so related rewards…

### DIFF
--- a/TwitchChatBot.Core/Services/AlertReplayService.cs
+++ b/TwitchChatBot.Core/Services/AlertReplayService.cs
@@ -12,7 +12,7 @@ namespace TwitchChatBot.Core.Services
         private readonly ICommandAlertService _command;
         private readonly ITwitchAlertTypesService _twitch;
         private readonly ITtsService _tts;
-        private readonly ITwitchClientWrapper _twitchClient; // for sendMessage delegate
+        private readonly IChatMessageService _chatMessageService; // for sendMessage delegate
         private readonly IAppFlags _appFlags;
 
         public AlertReplayService(
@@ -22,7 +22,7 @@ namespace TwitchChatBot.Core.Services
             ICommandAlertService commandAlertService,
             ITwitchAlertTypesService twitchAlertTypesService,
             ITtsService ttsService,
-            ITwitchClientWrapper twitchClient,
+            IChatMessageService chatMessageService,
             IAppFlags appFlags)
         {
             _logger = logger;
@@ -31,7 +31,7 @@ namespace TwitchChatBot.Core.Services
             _command = commandAlertService;
             _twitch = twitchAlertTypesService;
             _tts = ttsService;
-            _twitchClient = twitchClient;
+            _chatMessageService = chatMessageService;
             _appFlags = appFlags;
         }
 
@@ -56,7 +56,7 @@ namespace TwitchChatBot.Core.Services
 
                     case AlertHistoryType.Cmd:
                         if (!string.IsNullOrWhiteSpace(e.CommandText))
-                            await _command.HandleCommandAsync(e.CommandText, e.UserId, e.Username ?? AppSettings.Ads.DefaultUserName, AppSettings.Twitch.TWITCH_CHANNEL, _twitchClient.SendMessage);
+                            await _command.HandleCommandAsync(e.CommandText, e.UserId, e.Username ?? AppSettings.Ads.DefaultUserName, AppSettings.Twitch.TWITCH_CHANNEL, _chatMessageService.SendMessage);
                         else
                             _logger.LogWarning("Replay Cmd: missing CommandText.");
                         break;

--- a/TwitchChatBot.Core/Services/ChannelPointRedemptionLockService.cs
+++ b/TwitchChatBot.Core/Services/ChannelPointRedemptionLockService.cs
@@ -1,0 +1,100 @@
+﻿using Microsoft.Extensions.Logging;
+using TwitchChatBot.Core.Services.Contracts;
+using TwitchChatBot.Models;
+
+namespace TwitchChatBot.Core.Services
+{
+	public class ChannelPointRedemptionLockService : IChannelPointRedemptionLockService
+	{
+		private readonly ILogger<ChannelPointRedemptionLockService> _logger;
+		private readonly HashSet<string> _usedRewardGroups = new(StringComparer.OrdinalIgnoreCase);
+
+		// TODO: Move reward lock groups to JSON configuration after mutual exclusion behavior is proven.
+		private readonly List<ChannelPointRewardLockGroup> _lockGroups = new()
+		{
+			new ChannelPointRewardLockGroup
+			{
+				GroupName = "DogTreats",
+				RewardTitles = new List<string>
+				{
+					"Justice For Puppies",
+					"Triple Justice"
+				}
+			}
+		};
+
+		public ChannelPointRedemptionLockService(ILogger<ChannelPointRedemptionLockService> logger)
+		{
+			_logger = logger;
+		}
+
+		public ChannelPointLockResult TryUseRewardGroup(string userId, string userName, string rewardTitle)
+		{
+			var lockGroup = _lockGroups.FirstOrDefault(group =>
+				group.RewardTitles.Any(title =>
+					string.Equals(title, rewardTitle, StringComparison.OrdinalIgnoreCase)));
+
+			if (lockGroup == null)
+			{
+				return new ChannelPointLockResult
+				{
+					IsAllowed = true
+				};
+			}
+
+			var lockUserKey = GetLockUserKey(userId, userName);
+			var lockKey = $"{lockUserKey}:{lockGroup.GroupName}";
+
+			if (_usedRewardGroups.Contains(lockKey))
+			{
+				var message = $"@{userName} you already used a Justice treat reward this stream. Pick one: Justice For Puppies OR Triple Justice.";
+
+				_logger.LogInformation(
+					"Blocked channel point redemption. User={UserName}, UserId={UserId}, RewardTitle={RewardTitle}, Group={GroupName}",
+					userName,
+					userId,
+					rewardTitle,
+					lockGroup.GroupName);
+
+				return new ChannelPointLockResult
+				{
+					IsAllowed = false,
+					GroupName = lockGroup.GroupName,
+					Message = message
+				};
+			}
+
+			_usedRewardGroups.Add(lockKey);
+
+			_logger.LogInformation(
+				"Marked channel point reward lock group as used. User={UserName}, UserId={UserId}, RewardTitle={RewardTitle}, Group={GroupName}",
+				userName,
+				userId,
+				rewardTitle,
+				lockGroup.GroupName);
+
+			return new ChannelPointLockResult
+			{
+				IsAllowed = true,
+				GroupName = lockGroup.GroupName
+			};
+		}
+
+		public void Clear()
+		{
+			_usedRewardGroups.Clear();
+
+			_logger.LogInformation("Cleared channel point redemption lock groups.");
+		}
+
+		private string GetLockUserKey(string userId, string userName)
+		{
+			if (!string.IsNullOrWhiteSpace(userId))
+			{
+				return userId.Trim();
+			}
+
+			return userName.Trim();
+		}
+	}
+}

--- a/TwitchChatBot.Core/Services/ChannelPointRedemptionService.cs
+++ b/TwitchChatBot.Core/Services/ChannelPointRedemptionService.cs
@@ -1,0 +1,116 @@
+﻿using Microsoft.Extensions.Logging;
+using TwitchChatBot.Core.Services.Contracts;
+using TwitchChatBot.Models;
+
+namespace TwitchChatBot.Core.Services
+{
+	public class ChannelPointRedemptionService : IChannelPointRedemptionService
+	{
+		private readonly ILogger<ChannelPointRedemptionService> _logger;
+		private readonly IChannelPointRedemptionLockService _channelPointRedemptionLockService;
+		private readonly ITwitchAlertTypesService _twitchAlertTypesService;
+		private readonly IChatMessageService _chatMessageService;
+		private readonly IChannelPointRedemptionStatusService _channelPointRedemptionStatusService;
+
+		public ChannelPointRedemptionService(
+			ILogger<ChannelPointRedemptionService> logger,
+			IChannelPointRedemptionLockService channelPointRedemptionLockService,
+			ITwitchAlertTypesService twitchAlertTypesService,
+			IChatMessageService chatMessageService,
+			IChannelPointRedemptionStatusService channelPointRedemptionStatusService)
+		{
+			_logger = logger;
+			_channelPointRedemptionLockService = channelPointRedemptionLockService;
+			_twitchAlertTypesService = twitchAlertTypesService;
+			_chatMessageService = chatMessageService;
+			_channelPointRedemptionStatusService = channelPointRedemptionStatusService;
+		}
+
+		public async Task HandleRedemptionAsync(ChannelPointRedemptionEvent redemption)
+		{
+			try
+			{
+				if (redemption == null)
+				{
+					_logger.LogWarning("Channel point redemption was null.");
+					return;
+				}
+
+				var lockResult = _channelPointRedemptionLockService.TryUseRewardGroup(
+					redemption.UserId,
+					redemption.UserName,
+					redemption.RewardTitle);
+
+				if (!lockResult.IsAllowed)
+				{
+					await HandleIsNotAllowed(redemption, lockResult);
+
+					return;
+				}
+
+				_logger.LogInformation(
+					"Channel point redemption allowed. User={UserName}, RewardTitle={RewardTitle}, Group={GroupName}",
+					redemption.UserName,
+					redemption.RewardTitle,
+					lockResult.GroupName);
+
+				await _twitchAlertTypesService.HandleChannelPointRedemptionAsync(
+					redemption.UserName,
+					redemption.RewardTitle);
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Unexpected error while handling channel point redemption. User={UserName}, RewardTitle={RewardTitle}, RedemptionId={RedemptionId}, RewardId={RewardId}",
+					redemption?.UserName,
+					redemption?.RewardTitle,
+					redemption?.RedemptionId,
+					redemption?.RewardId);
+			}
+		}
+
+		private async Task HandleIsNotAllowed(ChannelPointRedemptionEvent redemption, ChannelPointLockResult lockResult)
+		{
+			_logger.LogInformation(
+					"Channel point redemption blocked. User={UserName}, RewardTitle={RewardTitle}, Group={GroupName}, Message={Message}",
+					redemption.UserName,
+					redemption.RewardTitle,
+					lockResult.GroupName,
+					lockResult.Message);
+
+			_chatMessageService.SendMessage(
+				AppSettings.Twitch.TWITCH_CHANNEL!,
+				lockResult.Message);
+
+			if (string.IsNullOrWhiteSpace(redemption.Status) ||
+				string.Equals(redemption.Status, "unfulfilled", StringComparison.OrdinalIgnoreCase))
+			{
+				var cancelSucceeded = await _channelPointRedemptionStatusService.TryCancelRedemptionAsync(
+					redemption.RedemptionId,
+					redemption.RewardId);
+
+				if (!cancelSucceeded)
+				{
+					_logger.LogWarning(
+						"Channel point redemption was blocked locally, but Twitch cancel/refund did not succeed. User={UserName}, RewardTitle={RewardTitle}, Status={Status}, RedemptionId={RedemptionId}, RewardId={RewardId}",
+						redemption.UserName,
+						redemption.RewardTitle,
+						redemption.Status,
+						redemption.RedemptionId,
+						redemption.RewardId);
+				}
+			}
+			else
+			{
+				_logger.LogInformation(
+					"Channel point redemption was blocked locally, but cancel/refund was skipped because status was not unfulfilled. User={UserName}, RewardTitle={RewardTitle}, Status={Status}, RedemptionId={RedemptionId}, RewardId={RewardId}",
+					redemption.UserName,
+					redemption.RewardTitle,
+					redemption.Status,
+					redemption.RedemptionId,
+					redemption.RewardId);
+			}
+		}
+	}
+}

--- a/TwitchChatBot.Core/Services/ChannelPointRedemptionStatusService.cs
+++ b/TwitchChatBot.Core/Services/ChannelPointRedemptionStatusService.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.Extensions.Logging;
+using System.Net.Http.Json;
+using TwitchChatBot.Core.Services.Contracts;
+using TwitchChatBot.Models;
+
+namespace TwitchChatBot.Core.Services
+{
+	public class ChannelPointRedemptionStatusService : IChannelPointRedemptionStatusService
+	{
+		private readonly ILogger<ChannelPointRedemptionStatusService> _logger;
+		private readonly IHttpClientFactory _httpClientFactory;
+
+		public ChannelPointRedemptionStatusService(
+			ILogger<ChannelPointRedemptionStatusService> logger,
+			IHttpClientFactory httpClientFactory)
+		{
+			_logger = logger;
+			_httpClientFactory = httpClientFactory;
+		}
+
+		public async Task<bool> TryCancelRedemptionAsync(
+			string redemptionId,
+			string rewardId,
+			CancellationToken cancellationToken = default)
+		{
+			if (string.IsNullOrWhiteSpace(redemptionId))
+			{
+				_logger.LogWarning("Cannot cancel channel point redemption because redemption id was empty.");
+				return false;
+			}
+
+			if (string.IsNullOrWhiteSpace(rewardId))
+			{
+				_logger.LogWarning("Cannot cancel channel point redemption because reward id was empty.");
+				return false;
+			}
+
+			if (string.IsNullOrWhiteSpace(AppSettings.Auth.TWITCH_ACCESS_TOKEN) ||
+				string.IsNullOrWhiteSpace(AppSettings.Auth.TWITCH_CLIENT_ID) ||
+				string.IsNullOrWhiteSpace(AppSettings.Twitch.TWITCH_USER_ID))
+			{
+				_logger.LogWarning("Cannot cancel channel point redemption because Twitch credentials are missing.");
+				return false;
+			}
+
+			try
+			{
+				var httpClient = _httpClientFactory.CreateClient("twitch-helix");
+
+				var url =
+					$"https://api.twitch.tv/helix/channel_points/custom_rewards/redemptions" +
+					$"?broadcaster_id={Uri.EscapeDataString(AppSettings.Twitch.TWITCH_USER_ID!)}" +
+					$"&reward_id={Uri.EscapeDataString(rewardId)}" +
+					$"&id={Uri.EscapeDataString(redemptionId)}";
+
+				var body = new
+				{
+					status = "CANCELED"
+				};
+
+				var response = await httpClient.PatchAsJsonAsync(url, body, cancellationToken);
+
+				if (response.IsSuccessStatusCode)
+				{
+					_logger.LogInformation(
+						"Canceled/refunded channel point redemption. RedemptionId={RedemptionId}, RewardId={RewardId}",
+						redemptionId,
+						rewardId);
+
+					return true;
+				}
+
+				var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+
+				_logger.LogWarning(
+					"Failed to cancel/refund channel point redemption. StatusCode={StatusCode}, Body={Body}, RedemptionId={RedemptionId}, RewardId={RewardId}",
+					response.StatusCode,
+					responseBody,
+					redemptionId,
+					rewardId);
+
+				return false;
+			}
+			catch (Exception ex)
+			{
+				_logger.LogWarning(
+					ex,
+					"Exception while trying to cancel/refund channel point redemption. RedemptionId={RedemptionId}, RewardId={RewardId}",
+					redemptionId,
+					rewardId);
+
+				return false;
+			}
+		}
+	}
+}

--- a/TwitchChatBot.Core/Services/ChatMessageService.cs
+++ b/TwitchChatBot.Core/Services/ChatMessageService.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.Logging;
+using TwitchChatBot.Core.Services.Contracts;
+
+namespace TwitchChatBot.Core.Services
+{
+	public class ChatMessageService : IChatMessageService
+	{
+		private readonly ILogger<ChatMessageService> _logger;
+		private readonly ITwitchClientWrapper _twitchClientWrapper;
+
+		public ChatMessageService(
+			ILogger<ChatMessageService> logger,
+			ITwitchClientWrapper twitchClientWrapper)
+		{
+			_logger = logger;
+			_twitchClientWrapper = twitchClientWrapper;
+		}
+
+		public void SendMessage(string channel, string message)
+		{
+			if (string.IsNullOrWhiteSpace(channel))
+			{
+				_logger.LogWarning("Cannot send chat message because channel was empty.");
+				return;
+			}
+
+			if (string.IsNullOrWhiteSpace(message))
+			{
+				_logger.LogWarning("Cannot send chat message because message was empty.");
+				return;
+			}
+
+			_twitchClientWrapper.SendMessage(channel, message);
+		}
+	}
+}

--- a/TwitchChatBot.Core/Services/Contracts/IChannelPointRedemptionLockService.cs
+++ b/TwitchChatBot.Core/Services/Contracts/IChannelPointRedemptionLockService.cs
@@ -1,0 +1,10 @@
+﻿using TwitchChatBot.Models;
+
+namespace TwitchChatBot.Core.Services.Contracts
+{
+	public interface IChannelPointRedemptionLockService
+	{
+		ChannelPointLockResult TryUseRewardGroup(string userId, string userName, string rewardTitle);
+		void Clear();
+	}
+}

--- a/TwitchChatBot.Core/Services/Contracts/IChannelPointRedemptionService.cs
+++ b/TwitchChatBot.Core/Services/Contracts/IChannelPointRedemptionService.cs
@@ -1,0 +1,9 @@
+﻿using TwitchChatBot.Models;
+
+namespace TwitchChatBot.Core.Services.Contracts
+{
+	public interface IChannelPointRedemptionService
+	{
+		Task HandleRedemptionAsync(ChannelPointRedemptionEvent redemption);
+	}
+}

--- a/TwitchChatBot.Core/Services/Contracts/IChannelPointRedemptionStatusService.cs
+++ b/TwitchChatBot.Core/Services/Contracts/IChannelPointRedemptionStatusService.cs
@@ -1,0 +1,10 @@
+﻿namespace TwitchChatBot.Core.Services.Contracts
+{
+	public interface IChannelPointRedemptionStatusService
+	{
+		Task<bool> TryCancelRedemptionAsync(
+			string redemptionId,
+			string rewardId,
+			CancellationToken cancellationToken = default);
+	}
+}

--- a/TwitchChatBot.Core/Services/Contracts/IChatMessageService.cs
+++ b/TwitchChatBot.Core/Services/Contracts/IChatMessageService.cs
@@ -1,0 +1,7 @@
+﻿namespace TwitchChatBot.Core.Services.Contracts
+{
+	public interface IChatMessageService
+	{
+		void SendMessage(string channel, string message);
+	}
+}

--- a/TwitchChatBot.Core/Services/TwitchAlertTypesService.cs
+++ b/TwitchChatBot.Core/Services/TwitchAlertTypesService.cs
@@ -522,7 +522,7 @@ namespace TwitchChatBot.Core.Services
             }
         }
 
-        private void EnqueueAlertWithMedia(string message, string mediaPath)
+		private void EnqueueAlertWithMedia(string message, string mediaPath)
         {
             if (string.IsNullOrWhiteSpace(mediaPath))
                 return;

--- a/TwitchChatBot.Core/Services/WheelService.cs
+++ b/TwitchChatBot.Core/Services/WheelService.cs
@@ -9,7 +9,7 @@ namespace TwitchChatBot.Core.Services
 	public class WheelService : IWheelService
 	{
 		private readonly IWheelRepository _wheelRepository;
-		private readonly ITwitchClientWrapper _twitchClientWrapper;
+		private readonly IChatMessageService _chatMessageService;
 		private readonly ITwitchAlertTypesService _twitchAlertTypesService;
 		private readonly ICommandAlertService _commandAlertService;
 		private readonly IAlertService _alertService;
@@ -21,7 +21,7 @@ namespace TwitchChatBot.Core.Services
 		
 		public WheelService(
 			IWheelRepository wheelRepository,
-			ITwitchClientWrapper twitchClientWrapper,
+			IChatMessageService chatMessageService,
 			ITwitchAlertTypesService twitchAlertTypesService,
 			ICommandAlertService commandAlertService,
 			IAlertService alertService,
@@ -30,7 +30,7 @@ namespace TwitchChatBot.Core.Services
 
 		{
 			_wheelRepository = wheelRepository;
-			_twitchClientWrapper = twitchClientWrapper;
+			_chatMessageService = chatMessageService;
 			_twitchAlertTypesService = twitchAlertTypesService;
 			_commandAlertService = commandAlertService;
 			_alertService = alertService;
@@ -301,7 +301,7 @@ namespace TwitchChatBot.Core.Services
 								if (!string.IsNullOrWhiteSpace(item.AlertKey))
 								{
 									await _commandAlertService.HandleCommandAsync(item.AlertKey, AppSettings.Twitch.TWITCH_USER_ID, 
-										AppSettings.Twitch.TWITCH_CHANNEL!, AppSettings.Twitch.TWITCH_CHANNEL!, _twitchClientWrapper.SendMessage);
+										AppSettings.Twitch.TWITCH_CHANNEL!, AppSettings.Twitch.TWITCH_CHANNEL!, _chatMessageService.SendMessage);
 									return;
 								}
 								_logger.LogWarning("Wheel item missing AlertKey for command");

--- a/TwitchChatBot.Models/ChannelPointLockResult.cs
+++ b/TwitchChatBot.Models/ChannelPointLockResult.cs
@@ -1,0 +1,9 @@
+﻿namespace TwitchChatBot.Models
+{
+	public class ChannelPointLockResult
+	{
+		public bool IsAllowed { get; set; }
+		public string GroupName { get; set; } = string.Empty;
+		public string Message { get; set; } = string.Empty;
+	}
+}

--- a/TwitchChatBot.Models/ChannelPointRedemptionEvent.cs
+++ b/TwitchChatBot.Models/ChannelPointRedemptionEvent.cs
@@ -1,0 +1,14 @@
+﻿namespace TwitchChatBot.Models
+{
+	public class ChannelPointRedemptionEvent
+	{
+		public string RedemptionId { get; set; } = string.Empty;
+		public string RewardId { get; set; } = string.Empty;
+		public string RewardTitle { get; set; } = string.Empty;
+		public string UserId { get; set; } = string.Empty;
+		public string UserName { get; set; } = string.Empty;
+		public string UserLogin { get; set; } = string.Empty;
+		public string Status { get; set; } = string.Empty;
+		public string UserInput { get; set; } = string.Empty;
+	}
+}

--- a/TwitchChatBot.Models/ChannelPointRewardLockGroup.cs
+++ b/TwitchChatBot.Models/ChannelPointRewardLockGroup.cs
@@ -1,0 +1,8 @@
+﻿namespace TwitchChatBot.Models
+{
+	public class ChannelPointRewardLockGroup
+	{
+		public string GroupName { get; set; } = string.Empty;
+		public List<string> RewardTitles { get; set; } = new();
+	}
+}

--- a/TwitchChatBot.Tests/Core/ChannelPointRedemptionLockServiceTests.cs
+++ b/TwitchChatBot.Tests/Core/ChannelPointRedemptionLockServiceTests.cs
@@ -1,0 +1,158 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TwitchChatBot.Core.Services;
+using Xunit;
+
+namespace TwitchChatBot.Tests.Core
+{
+	public class ChannelPointRedemptionLockServiceTests
+	{
+		private readonly Mock<ILogger<ChannelPointRedemptionLockService>> _loggerMock;
+
+		public ChannelPointRedemptionLockServiceTests()
+		{
+			_loggerMock = new Mock<ILogger<ChannelPointRedemptionLockService>>();
+		}
+
+		[Fact]
+		public void TryUseRewardGroup_ShouldAllowReward_WhenRewardIsNotInLockGroup()
+		{
+			var service = CreateService();
+
+			var result = service.TryUseRewardGroup(
+				"user-123",
+				"TestUser",
+				"Some Other Reward");
+
+			result.IsAllowed.Should().BeTrue();
+			result.GroupName.Should().BeEmpty();
+			result.Message.Should().BeEmpty();
+		}
+
+		[Fact]
+		public void TryUseRewardGroup_ShouldAllowFirstRewardInLockGroup()
+		{
+			var service = CreateService();
+
+			var result = service.TryUseRewardGroup(
+				"user-123",
+				"TestUser",
+				"Justice For Puppies");
+
+			result.IsAllowed.Should().BeTrue();
+			result.GroupName.Should().Be("DogTreats");
+			result.Message.Should().BeEmpty();
+		}
+
+		[Fact]
+		public void TryUseRewardGroup_ShouldBlockSecondRewardInSameLockGroupForSameUser()
+		{
+			var service = CreateService();
+
+			service.TryUseRewardGroup(
+				"user-123",
+				"TestUser",
+				"Justice For Puppies");
+
+			var result = service.TryUseRewardGroup(
+				"user-123",
+				"TestUser",
+				"Triple Justice");
+
+			result.IsAllowed.Should().BeFalse();
+			result.GroupName.Should().Be("DogTreats");
+			result.Message.Should().Contain("@TestUser");
+			result.Message.Should().Contain("Justice For Puppies");
+			result.Message.Should().Contain("Triple Justice");
+		}
+
+		[Fact]
+		public void TryUseRewardGroup_ShouldNotBlockDifferentUsersInSameLockGroup()
+		{
+			var service = CreateService();
+
+			var firstUserResult = service.TryUseRewardGroup(
+				"user-123",
+				"FirstUser",
+				"Justice For Puppies");
+
+			var secondUserResult = service.TryUseRewardGroup(
+				"user-456",
+				"SecondUser",
+				"Triple Justice");
+
+			firstUserResult.IsAllowed.Should().BeTrue();
+			secondUserResult.IsAllowed.Should().BeTrue();
+		}
+
+		[Fact]
+		public void TryUseRewardGroup_ShouldMatchRewardTitlesCaseInsensitive()
+		{
+			var service = CreateService();
+
+			service.TryUseRewardGroup(
+				"user-123",
+				"TestUser",
+				"justice for puppies");
+
+			var result = service.TryUseRewardGroup(
+				"user-123",
+				"TestUser",
+				"TRIPLE JUSTICE");
+
+			result.IsAllowed.Should().BeFalse();
+			result.GroupName.Should().Be("DogTreats");
+		}
+
+		[Fact]
+		public void Clear_ShouldResetUsedRewardGroups()
+		{
+			var service = CreateService();
+
+			service.TryUseRewardGroup(
+				"user-123",
+				"TestUser",
+				"Justice For Puppies");
+
+			var blockedResult = service.TryUseRewardGroup(
+				"user-123",
+				"TestUser",
+				"Triple Justice");
+
+			service.Clear();
+
+			var allowedAfterClearResult = service.TryUseRewardGroup(
+				"user-123",
+				"TestUser",
+				"Triple Justice");
+
+			blockedResult.IsAllowed.Should().BeFalse();
+			allowedAfterClearResult.IsAllowed.Should().BeTrue();
+		}
+
+		[Fact]
+		public void TryUseRewardGroup_ShouldFallbackToUserName_WhenUserIdIsEmpty()
+		{
+			var service = CreateService();
+
+			service.TryUseRewardGroup(
+				string.Empty,
+				"TestUser",
+				"Justice For Puppies");
+
+			var result = service.TryUseRewardGroup(
+				string.Empty,
+				"TestUser",
+				"Triple Justice");
+
+			result.IsAllowed.Should().BeFalse();
+			result.GroupName.Should().Be("DogTreats");
+		}
+
+		private ChannelPointRedemptionLockService CreateService()
+		{
+			return new ChannelPointRedemptionLockService(_loggerMock.Object);
+		}
+	}
+}

--- a/TwitchChatBot.Tests/Core/ChannelPointRedemptionServiceTests.cs
+++ b/TwitchChatBot.Tests/Core/ChannelPointRedemptionServiceTests.cs
@@ -1,0 +1,314 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TwitchChatBot.Core.Services;
+using TwitchChatBot.Core.Services.Contracts;
+using TwitchChatBot.Models;
+using Xunit;
+
+namespace TwitchChatBot.Tests.Core
+{
+	public class ChannelPointRedemptionServiceTests
+	{
+		private readonly Mock<ILogger<ChannelPointRedemptionService>> _loggerMock;
+		private readonly Mock<IChannelPointRedemptionLockService> _lockServiceMock;
+		private readonly Mock<ITwitchAlertTypesService> _twitchAlertTypesServiceMock;
+		private readonly Mock<IChatMessageService> _chatMessageServiceMock;
+		private readonly Mock<IChannelPointRedemptionStatusService> _redemptionStatusServiceMock;
+
+		public ChannelPointRedemptionServiceTests()
+		{
+			_loggerMock = new Mock<ILogger<ChannelPointRedemptionService>>();
+			_lockServiceMock = new Mock<IChannelPointRedemptionLockService>();
+			_twitchAlertTypesServiceMock = new Mock<ITwitchAlertTypesService>();
+			_chatMessageServiceMock = new Mock<IChatMessageService>();
+			_redemptionStatusServiceMock = new Mock<IChannelPointRedemptionStatusService>();
+
+			var config = BuildConfiguration();
+			AppSettings.Configuration = config;
+		}
+
+		[Fact]
+		public async Task HandleRedemptionAsync_Should_CallAlertService_WhenRedemptionIsAllowed()
+		{
+			var service = CreateService();
+			var redemption = CreateRedemption();
+
+			_lockServiceMock
+				.Setup(x => x.TryUseRewardGroup(
+					redemption.UserId,
+					redemption.UserName,
+					redemption.RewardTitle))
+				.Returns(new ChannelPointLockResult
+				{
+					IsAllowed = true,
+					GroupName = "DogTreats"
+				});
+
+			await service.HandleRedemptionAsync(redemption);
+
+			_twitchAlertTypesServiceMock.Verify(
+				x => x.HandleChannelPointRedemptionAsync(
+					redemption.UserName,
+					redemption.RewardTitle),
+				Times.Once);
+
+			_chatMessageServiceMock.Verify(
+				x => x.SendMessage(It.IsAny<string>(), It.IsAny<string>()),
+				Times.Never);
+
+			_redemptionStatusServiceMock.Verify(
+				x => x.TryCancelRedemptionAsync(
+					It.IsAny<string>(),
+					It.IsAny<string>(),
+					It.IsAny<CancellationToken>()),
+				Times.Never);
+		}
+
+		[Fact]
+		public async Task HandleRedemptionAsync_Should_NotCallAlertService_WhenRedemptionIsBlocked()
+		{
+			var service = CreateService();
+			var redemption = CreateRedemption();
+
+			_lockServiceMock
+				.Setup(x => x.TryUseRewardGroup(
+					redemption.UserId,
+					redemption.UserName,
+					redemption.RewardTitle))
+				.Returns(new ChannelPointLockResult
+				{
+					IsAllowed = false,
+					GroupName = "DogTreats",
+					Message = "@TestUser you already used a Justice treat reward this stream."
+				});
+
+			_redemptionStatusServiceMock
+				.Setup(x => x.TryCancelRedemptionAsync(
+					redemption.RedemptionId,
+					redemption.RewardId,
+					It.IsAny<CancellationToken>()))
+				.ReturnsAsync(true);
+
+			await service.HandleRedemptionAsync(redemption);
+
+			_twitchAlertTypesServiceMock.Verify(
+				x => x.HandleChannelPointRedemptionAsync(
+					It.IsAny<string>(),
+					It.IsAny<string>()),
+				Times.Never);
+		}
+
+		[Fact]
+		public async Task HandleRedemptionAsync_Should_SendChatFeedback_WhenRedemptionIsBlocked()
+		{
+			var service = CreateService();
+			var redemption = CreateRedemption();
+			var message = "@TestUser you already used a Justice treat reward this stream.";
+
+			_lockServiceMock
+				.Setup(x => x.TryUseRewardGroup(
+					redemption.UserId,
+					redemption.UserName,
+					redemption.RewardTitle))
+				.Returns(new ChannelPointLockResult
+				{
+					IsAllowed = false,
+					GroupName = "DogTreats",
+					Message = message
+				});
+
+			_redemptionStatusServiceMock
+				.Setup(x => x.TryCancelRedemptionAsync(
+					redemption.RedemptionId,
+					redemption.RewardId,
+					It.IsAny<CancellationToken>()))
+				.ReturnsAsync(true);
+
+			await service.HandleRedemptionAsync(redemption);
+
+			_chatMessageServiceMock.Verify(
+				x => x.SendMessage(
+					AppSettings.Twitch.TWITCH_CHANNEL!,
+					message),
+				Times.Once);
+		}
+
+		[Fact]
+		public async Task HandleRedemptionAsync_Should_AttemptCancelRefund_WhenBlockedAndStatusIsUnfulfilled()
+		{
+			var service = CreateService();
+			var redemption = CreateRedemption();
+			redemption.Status = "unfulfilled";
+
+			_lockServiceMock
+				.Setup(x => x.TryUseRewardGroup(
+					redemption.UserId,
+					redemption.UserName,
+					redemption.RewardTitle))
+				.Returns(new ChannelPointLockResult
+				{
+					IsAllowed = false,
+					GroupName = "DogTreats",
+					Message = "Blocked message"
+				});
+
+			_redemptionStatusServiceMock
+				.Setup(x => x.TryCancelRedemptionAsync(
+					redemption.RedemptionId,
+					redemption.RewardId,
+					It.IsAny<CancellationToken>()))
+				.ReturnsAsync(true);
+
+			await service.HandleRedemptionAsync(redemption);
+
+			_redemptionStatusServiceMock.Verify(
+				x => x.TryCancelRedemptionAsync(
+					redemption.RedemptionId,
+					redemption.RewardId,
+					It.IsAny<CancellationToken>()),
+				Times.Once);
+		}
+
+		[Fact]
+		public async Task HandleRedemptionAsync_Should_AttemptCancelRefund_WhenBlockedAndStatusIsEmpty()
+		{
+			var service = CreateService();
+			var redemption = CreateRedemption();
+			redemption.Status = string.Empty;
+
+			_lockServiceMock
+				.Setup(x => x.TryUseRewardGroup(
+					redemption.UserId,
+					redemption.UserName,
+					redemption.RewardTitle))
+				.Returns(new ChannelPointLockResult
+				{
+					IsAllowed = false,
+					GroupName = "DogTreats",
+					Message = "Blocked message"
+				});
+
+			_redemptionStatusServiceMock
+				.Setup(x => x.TryCancelRedemptionAsync(
+					redemption.RedemptionId,
+					redemption.RewardId,
+					It.IsAny<CancellationToken>()))
+				.ReturnsAsync(true);
+
+			await service.HandleRedemptionAsync(redemption);
+
+			_redemptionStatusServiceMock.Verify(
+				x => x.TryCancelRedemptionAsync(
+					redemption.RedemptionId,
+					redemption.RewardId,
+					It.IsAny<CancellationToken>()),
+				Times.Once);
+		}
+
+		[Fact]
+		public async Task HandleRedemptionAsync_Should_NotAttemptCancelRefund_WhenBlockedAndStatusIsFulfilled()
+		{
+			var service = CreateService();
+			var redemption = CreateRedemption();
+			redemption.Status = "fulfilled";
+
+			_lockServiceMock
+				.Setup(x => x.TryUseRewardGroup(
+					redemption.UserId,
+					redemption.UserName,
+					redemption.RewardTitle))
+				.Returns(new ChannelPointLockResult
+				{
+					IsAllowed = false,
+					GroupName = "DogTreats",
+					Message = "Blocked message"
+				});
+
+			await service.HandleRedemptionAsync(redemption);
+
+			_redemptionStatusServiceMock.Verify(
+				x => x.TryCancelRedemptionAsync(
+					It.IsAny<string>(),
+					It.IsAny<string>(),
+					It.IsAny<CancellationToken>()),
+				Times.Never);
+		}
+
+		[Fact]
+		public async Task HandleRedemptionAsync_Should_NotThrow_WhenRedemptionIsNull()
+		{
+			var service = CreateService();
+
+			var act = async () => await service.HandleRedemptionAsync(null!);
+
+			await act.Should().NotThrowAsync();
+
+			_twitchAlertTypesServiceMock.Verify(
+				x => x.HandleChannelPointRedemptionAsync(
+					It.IsAny<string>(),
+					It.IsAny<string>()),
+				Times.Never);
+		}
+
+		[Fact]
+		public async Task HandleRedemptionAsync_Should_NotThrow_WhenLockServiceThrows()
+		{
+			var service = CreateService();
+			var redemption = CreateRedemption();
+
+			_lockServiceMock
+				.Setup(x => x.TryUseRewardGroup(
+					redemption.UserId,
+					redemption.UserName,
+					redemption.RewardTitle))
+				.Throws(new InvalidOperationException("Test exception"));
+
+			var act = async () => await service.HandleRedemptionAsync(redemption);
+
+			await act.Should().NotThrowAsync();
+
+			_twitchAlertTypesServiceMock.Verify(
+				x => x.HandleChannelPointRedemptionAsync(
+					It.IsAny<string>(),
+					It.IsAny<string>()),
+				Times.Never);
+		}
+
+		private ChannelPointRedemptionService CreateService()
+		{
+			return new ChannelPointRedemptionService(
+				_loggerMock.Object,
+				_lockServiceMock.Object,
+				_twitchAlertTypesServiceMock.Object,
+				_chatMessageServiceMock.Object,
+				_redemptionStatusServiceMock.Object);
+		}
+
+		private static ChannelPointRedemptionEvent CreateRedemption()
+		{
+			return new ChannelPointRedemptionEvent
+			{
+				RedemptionId = "redemption-123",
+				RewardId = "reward-456",
+				RewardTitle = "Triple Justice",
+				UserId = "user-789",
+				UserName = "TestUser",
+				UserLogin = "testuser",
+				Status = "unfulfilled",
+				UserInput = string.Empty
+			};
+		}
+
+		private static IConfiguration BuildConfiguration()
+		{
+			return new ConfigurationBuilder()
+				.AddInMemoryCollection(new Dictionary<string, string?>
+				{
+					["Twitch:Channel"] = "legendofsacks"
+				})
+				.Build();
+		}
+	}
+}

--- a/TwitchChatBot.Tests/Core/TwitchAlertTypesServiceTests.cs
+++ b/TwitchChatBot.Tests/Core/TwitchAlertTypesServiceTests.cs
@@ -103,10 +103,12 @@ namespace TwitchChatBot.Tests.Core
 
 			await _sut.HandleCheerAsync("Tyler", 350, "@chat lets go");
 
-			_alertServiceMock.Verify(x =>
-				x.EnqueueAlert(
-					It.IsAny<string>(),
-					It.Is<string>(m => m.Contains("tier350.mp4"))),
+			_alertServiceMock.Verify(
+				x => x.EnqueueAlert(It.Is<AlertItem>(item =>
+				item.Message.Contains("cheered", StringComparison.OrdinalIgnoreCase) &&
+				item.Message.Contains("350", StringComparison.OrdinalIgnoreCase) &&
+				item.MediaPath != null &&
+				item.MediaPath.Contains("tier350.mp4", StringComparison.OrdinalIgnoreCase))),
 				Times.Once);
 
 			_ttsServiceMock.Verify(x =>
@@ -147,10 +149,12 @@ namespace TwitchChatBot.Tests.Core
 
 			await _sut.HandleFollowAsync("Tyler");
 
-			_alertServiceMock.Verify(x =>
-				x.EnqueueAlert(
-					It.IsAny<string>(),
-					It.Is<string>(m => m.Contains("follow.mp4"))),
+			_alertServiceMock.Verify(
+				x => x.EnqueueAlert(It.Is<AlertItem>(item =>
+				item.Message.Contains("Tyler", StringComparison.OrdinalIgnoreCase) &&
+				item.Message.Contains("just followed", StringComparison.OrdinalIgnoreCase) &&
+				item.MediaPath != null &&
+				item.MediaPath.Contains("follow.mp4", StringComparison.OrdinalIgnoreCase))),
 				Times.Once);
 
 			_ttsServiceMock.Verify(x =>
@@ -200,10 +204,11 @@ namespace TwitchChatBot.Tests.Core
 
 			await _sut.HandleChannelPointRedemptionAsync("Tyler", "KOBE");
 
-			_alertServiceMock.Verify(x =>
-				x.EnqueueAlert(
-					It.IsAny<string>(),
-					It.Is<string>(m => m.Contains("kobe.mp4"))),
+			_alertServiceMock.Verify(
+				x => x.EnqueueAlert(It.Is<AlertItem>(item =>
+				item.Message.Contains("redeemed", StringComparison.OrdinalIgnoreCase) &&
+				item.MediaPath != null &&
+				item.MediaPath.Contains("kobe.mp4", StringComparison.OrdinalIgnoreCase))),
 				Times.Once);
 
 			_ttsServiceMock.Verify(x =>

--- a/TwitchChatBot.Tests/Core/TwitchClientWrapperTests.cs
+++ b/TwitchChatBot.Tests/Core/TwitchClientWrapperTests.cs
@@ -234,7 +234,7 @@ namespace TwitchChatBot.Tests.Core
 			_helixLookupServiceMock.Setup(x => x.GetUserIdByLoginAsync("moduser", default)).ReturnsAsync("123");
 
 			await InvokePrivateAsync("HandleOnUserJoined", "moduser");
-			await InvokePrivateAsync("HandleOnUserLeft", "moduser");
+			InvokePrivate("HandleOnUserLeft", "moduser");
 
 			var result = _sut.GetGroupedViewers();
 

--- a/TwitchChatBot.Tests/Core/WheelServiceTests.cs
+++ b/TwitchChatBot.Tests/Core/WheelServiceTests.cs
@@ -14,7 +14,7 @@ namespace TwitchChatBot.Tests.Core
 	public class WheelServiceTests
 	{
 		private readonly Mock<IWheelRepository> _wheelRepositoryMock = new();
-		private readonly Mock<ITwitchClientWrapper> _twitchClientWrapperMock = new();
+		private readonly Mock<IChatMessageService> _chatMessageServiceMock = new();
 		private readonly Mock<ITwitchAlertTypesService> _twitchAlertTypeMock = new();
 		private readonly Mock<ICommandAlertService> _commandAlertServiceMock = new();
 		private readonly Mock<IAlertService> _alertServiceMock = new();
@@ -30,7 +30,7 @@ namespace TwitchChatBot.Tests.Core
 
 			_sut = new WheelService(
 				_wheelRepositoryMock.Object,
-				_twitchClientWrapperMock.Object,
+				_chatMessageServiceMock.Object,
 				_twitchAlertTypeMock.Object,
 				_commandAlertServiceMock.Object,
 				_alertServiceMock.Object,

--- a/TwitchChatBot/Program.cs
+++ b/TwitchChatBot/Program.cs
@@ -93,6 +93,9 @@ namespace TwitchChatBot
 			services.TryAddSingleton<IRandomProvider, RandomProvider>();
 			services.TryAddSingleton<IWheelService, WheelService>();
 			services.TryAddSingleton<IDonationAlertService, DonationAlertService>();
+			services.TryAddSingleton<IChannelPointRedemptionLockService, ChannelPointRedemptionLockService>();
+			services.TryAddSingleton<IChannelPointRedemptionService, ChannelPointRedemptionService>();
+			services.AddSingleton<IChatMessageService, ChatMessageService>();
 
 			services.TryAddSingleton<IFirstChatterAlertService>(sp =>
             new FirstChatterAlertService(

--- a/TwitchChatBot/Services/EventSubSocketService.cs
+++ b/TwitchChatBot/Services/EventSubSocketService.cs
@@ -13,8 +13,9 @@ namespace TwitchChatBot.UI.Services
         private readonly ILogger<EventSubSocketService> _logger;
         private readonly ITwitchAlertTypesService _twitchAlertTypesService;
         private readonly IHttpClientFactory _httpClientFactory;
+		private readonly IChannelPointRedemptionService _channelPointRedemptionService;
 
-        private readonly SemaphoreSlim _connectLock = new(1, 1);
+		private readonly SemaphoreSlim _connectLock = new(1, 1);
 
         private ClientWebSocket? _socket;
         private Task? _listenerTask;
@@ -31,11 +32,13 @@ namespace TwitchChatBot.UI.Services
         public EventSubSocketService(
             ILogger<EventSubSocketService> logger,
             ITwitchAlertTypesService twitchAlertTypesService,
-            IHttpClientFactory httpClientFactory)
+            IHttpClientFactory httpClientFactory,
+			IChannelPointRedemptionService channelPointRedemptionService)
         {
             _logger = logger;
             _twitchAlertTypesService = twitchAlertTypesService;
             _httpClientFactory = httpClientFactory;
+			_channelPointRedemptionService = channelPointRedemptionService;
         }
 
         public Task StartAsync(CancellationToken cancellationToken = default)
@@ -315,9 +318,7 @@ namespace TwitchChatBot.UI.Services
                                     }
                                 case TwitchEventTypes.ChannelPointsRedemption:
                                     {
-                                        userName = eventPayload.GetProperty("user_name").GetString() ?? userName;
-                                        var rewardTitle = eventPayload.GetProperty("reward").GetProperty("title").GetString() ?? "";
-                                        await _twitchAlertTypesService.HandleChannelPointRedemptionAsync(userName, rewardTitle);
+										await HandleChannelPointRedemptionAsync(eventPayload);
                                         break;
                                     }
                                 case TwitchEventTypes.HypeTrainBegin:
@@ -363,7 +364,26 @@ namespace TwitchChatBot.UI.Services
             }
         }
 
-        private async Task SubscribeToEvents(string? sessionId)
+		private async Task HandleChannelPointRedemptionAsync(JsonElement eventPayload)
+		{
+			var redemption = new ChannelPointRedemptionEvent
+			{
+				RedemptionId = eventPayload.GetProperty("id").GetString() ?? string.Empty,
+				UserId = eventPayload.GetProperty("user_id").GetString() ?? string.Empty,
+				UserName = eventPayload.GetProperty("user_name").GetString() ?? "someone",
+				UserLogin = eventPayload.GetProperty("user_login").GetString() ?? string.Empty,
+				Status = eventPayload.GetProperty("status").GetString() ?? string.Empty,
+				UserInput = eventPayload.TryGetProperty("user_input", out var userInput)
+					? userInput.GetString() ?? string.Empty
+					: string.Empty,
+				RewardId = eventPayload.GetProperty("reward").GetProperty("id").GetString() ?? string.Empty,
+				RewardTitle = eventPayload.GetProperty("reward").GetProperty("title").GetString() ?? string.Empty
+			};
+
+			await _channelPointRedemptionService.HandleRedemptionAsync(redemption);
+		}
+
+		private async Task SubscribeToEvents(string? sessionId)
         {
             if (sessionId == null)
             {

--- a/TwitchChatBot/TwitchChatBot.UI.csproj
+++ b/TwitchChatBot/TwitchChatBot.UI.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<UseWindowsForms>true</UseWindowsForms>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>2.3.1</Version>
+		<Version>2.3.2</Version>
 		<RepositoryUrl>https://github.com/gmblogref/TwitchChatBot</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<ApplicationIcon>baseball_icon.ico</ApplicationIcon>


### PR DESCRIPTION
## Changes

- Added channel point redemption models:
  - `ChannelPointRedemptionEvent`
  - `ChannelPointRewardLockGroup`
  - `ChannelPointLockResult`
- Added in-memory reward lock handling:
  - `IChannelPointRedemptionLockService`
  - `ChannelPointRedemptionLockService`
- Added channel point redemption orchestration:
  - `IChannelPointRedemptionService`
  - `ChannelPointRedemptionService`
- Added chat message abstraction:
  - `IChatMessageService`
  - `ChatMessageService`
- Added Twitch redemption cancel/refund attempt support:
  - `IChannelPointRedemptionStatusService`
  - `ChannelPointRedemptionStatusService`
- Updated EventSub channel point redemption handling to build a full redemption model and route through the new wrapper service.
- Added/updated DI registrations.
- Added named Twitch Helix HTTP client usage.
- Updated tests for the new lock/orchestration behavior.
- Repaired existing alert and wrapper tests affected by updated alert enqueue behavior.


## Behavior

- First reward redeemed in a lock group is allowed.
- Second reward from the same lock group by the same viewer is blocked.
- Blocked redemptions do not fire alerts.
- Blocked redemptions do not trigger treat behavior.
- Bot sends chat feedback when a redemption is blocked.
- Bot attempts Twitch cancel/refund when the blocked redemption is eligible.
- Refund/cancel failures are logged but do not crash the bot.
- Other viewers are not affected by another viewer’s lock.

## Testing

- Added `ChannelPointRedemptionLockServiceTests`
- Added `ChannelPointRedemptionServiceTests`
- Full test suite passing locally