### PR TITLE
Fix duplicate gift sub alerts for bulk gift subscriptions

### DIFF
--- a/TwitchChatBot.Core/Services/Contracts/IGiftSubBundleSuppressionService.cs
+++ b/TwitchChatBot.Core/Services/Contracts/IGiftSubBundleSuppressionService.cs
@@ -1,0 +1,9 @@
+﻿namespace TwitchChatBot.Core.Services.Contracts
+{
+	public interface IGiftSubBundleSuppressionService
+	{
+		void TrackBundle(string gifterKey, int expectedGiftCount);
+
+		bool ShouldSuppressIndividualGift(string gifterKey);
+	}
+}

--- a/TwitchChatBot.Core/Services/GiftSubBundleSuppressionService.cs
+++ b/TwitchChatBot.Core/Services/GiftSubBundleSuppressionService.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.Extensions.Logging;
+using TwitchChatBot.Core.Services.Contracts;
+using TwitchChatBot.Models;
+
+namespace TwitchChatBot.Core.Services
+{
+	public class GiftSubBundleSuppressionService : IGiftSubBundleSuppressionService
+	{
+		private readonly ILogger<GiftSubBundleSuppressionService> _logger;
+		private readonly Dictionary<string, GiftSubBundleSuppressionState> _activeSuppressions = new(StringComparer.OrdinalIgnoreCase);
+		private readonly object _lock = new();
+		private readonly TimeSpan _suppressionWindow = TimeSpan.FromSeconds(30);
+
+		public GiftSubBundleSuppressionService(ILogger<GiftSubBundleSuppressionService> logger)
+		{
+			_logger = logger;
+		}
+
+		public void TrackBundle(string gifterKey, int expectedGiftCount)
+		{
+			if (string.IsNullOrWhiteSpace(gifterKey))
+			{
+				return;
+			}
+
+			if (expectedGiftCount <= 1)
+			{
+				return;
+			}
+
+			lock (_lock)
+			{
+				_activeSuppressions[gifterKey] = new GiftSubBundleSuppressionState
+				{
+					GifterKey = gifterKey,
+					RemainingGiftCount = expectedGiftCount,
+					ExpiresAtUtc = DateTime.UtcNow.Add(_suppressionWindow)
+				};
+			}
+
+			_logger.LogInformation(
+				"🎁 Tracking gift sub bundle suppression for {GifterKey}. Expected individual gift events: {ExpectedGiftCount}",
+				gifterKey,
+				expectedGiftCount);
+		}
+
+		public bool ShouldSuppressIndividualGift(string gifterKey)
+		{
+			if (string.IsNullOrWhiteSpace(gifterKey))
+			{
+				return false;
+			}
+
+			lock (_lock)
+			{
+				if (!_activeSuppressions.TryGetValue(gifterKey, out var suppression))
+				{
+					return false;
+				}
+
+				if (DateTime.UtcNow > suppression.ExpiresAtUtc)
+				{
+					_activeSuppressions.Remove(gifterKey);
+
+					_logger.LogInformation(
+						"🎁 Gift sub suppression expired for {GifterKey}.",
+						gifterKey);
+
+					return false;
+				}
+
+				suppression.RemainingGiftCount--;
+
+				_logger.LogInformation(
+					"🎁 Suppressed individual gift sub for {GifterKey}. Remaining suppressed gifts: {RemainingGiftCount}",
+					gifterKey,
+					suppression.RemainingGiftCount);
+
+				if (suppression.RemainingGiftCount <= 0)
+				{
+					_activeSuppressions.Remove(gifterKey);
+
+					_logger.LogInformation(
+						"🎁 Gift sub suppression completed for {GifterKey}.",
+						gifterKey);
+				}
+
+				return true;
+			}
+		}
+	}
+}

--- a/TwitchChatBot.Core/Services/TwitchClientWrapper.cs
+++ b/TwitchChatBot.Core/Services/TwitchClientWrapper.cs
@@ -23,7 +23,8 @@ namespace TwitchChatBot.Core.Services
         private readonly IIRCNoticeService _ircNoticeService;
         private readonly ITwitchAlertTypesService _twitchAlertTypesService;
         private readonly IHelixLookupService _helixLookupService;
-        private System.Threading.Timer? _adTimer;
+		private readonly IGiftSubBundleSuppressionService _giftSubBundleSuppressionService;
+		private System.Threading.Timer? _adTimer;
         private bool _disposed = false;
 
         private readonly HashSet<string> _connectedUsers = new(StringComparer.OrdinalIgnoreCase);
@@ -59,7 +60,8 @@ namespace TwitchChatBot.Core.Services
                 IWatchStreakService watchStreakService,
                 IIRCNoticeService ircNoticeService,
                 ITwitchAlertTypesService twitchAlertTypesService,
-                IHelixLookupService helixLookupService)
+                IHelixLookupService helixLookupService,
+				IGiftSubBundleSuppressionService giftSubBundleSuppressionService)
         {
             _logger = logger;
             _commandAlertService = commandAlertService;
@@ -70,8 +72,9 @@ namespace TwitchChatBot.Core.Services
             _ircNoticeService = ircNoticeService;
             _twitchAlertTypesService = twitchAlertTypesService;
             _helixLookupService = helixLookupService;
+			_giftSubBundleSuppressionService = giftSubBundleSuppressionService;
 
-            try
+			try
             {
                 var credentials = new ConnectionCredentials(AppSettings.Twitch.TWITCH_BOT_USERNAME, AppSettings.Auth.TWITCH_OAUTH_TOKEN);
                 _twitchClient = new TwitchClient();
@@ -455,14 +458,14 @@ namespace TwitchChatBot.Core.Services
             }
         }
 
-        private async Task HandleOnNewSubscriberAsync(TwitchLib.Client.Events.OnNewSubscriberArgs e)
+        private async Task HandleOnNewSubscriberAsync(OnNewSubscriberArgs e)
         {
             var user = e.Subscriber?.DisplayName ?? e.Subscriber?.Login ?? AppSettings.Ads.DefaultUserName;
             var tier = ConvertPlanToTier(e.Subscriber?.MsgParamSubPlan);
             await _twitchAlertTypesService.HandleSubscriptionAsync(user, tier);
         }
 
-        private async Task HandleOnReSubscriberAsync(TwitchLib.Client.Events.OnReSubscriberArgs e)
+        private async Task HandleOnReSubscriberAsync(OnReSubscriberArgs e)
         {
             // DisplayName/Login
             var username = e.ReSubscriber?.DisplayName ?? e.ReSubscriber?.Login ?? AppSettings.Ads.DefaultUserName;
@@ -482,25 +485,42 @@ namespace TwitchChatBot.Core.Services
             await _twitchAlertTypesService.HandleResubAsync(username, months, message, tier);
         }
 
-        private async Task HandleOnGiftedSubscriptionAsync(TwitchLib.Client.Events.OnGiftedSubscriptionArgs e)
+        private async Task HandleOnGiftedSubscriptionAsync(OnGiftedSubscriptionArgs e)
         {
             var gifter = e.GiftedSubscription?.DisplayName ?? e.GiftedSubscription?.Login ?? AppSettings.Ads.DefaultUserName;
-            var recipient = e.GiftedSubscription?.MsgParamRecipientUserName ?? e.GiftedSubscription?.MsgParamRecipientUserName ?? AppSettings.Ads.DefaultUserName;
+            var recipient = e.GiftedSubscription?.MsgParamRecipientUserName ?? AppSettings.Ads.DefaultUserName;
             var tier = ConvertPlanToTier(e.GiftedSubscription?.MsgParamSubPlan);
-            await _twitchAlertTypesService.HandleSubGiftAsync(gifter, recipient, tier);
+
+			if (_giftSubBundleSuppressionService.ShouldSuppressIndividualGift(gifter))
+			{
+				_logger.LogInformation(
+					"🎁 Suppressed individual gifted sub from {Gifter} to {Recipient}.",
+					gifter,
+					recipient);
+
+				return;
+			}
+
+			await _twitchAlertTypesService.HandleSubGiftAsync(gifter, recipient, tier);
         }
 
-        private async Task HandleOnCommunitySubscriptionAsync(TwitchLib.Client.Events.OnCommunitySubscriptionArgs e)
+        private async Task HandleOnCommunitySubscriptionAsync(OnCommunitySubscriptionArgs e)
         {
             var gifter = e.GiftedSubscription?.DisplayName ?? e.GiftedSubscription?.Login ?? AppSettings.Ads.DefaultUserName;
             var count = (e.GiftedSubscription?.MsgParamMassGiftCount ?? 0) > 0
                 ? e.GiftedSubscription!.MsgParamMassGiftCount
                 : 1;
             var tier = ConvertPlanToTier(e.GiftedSubscription?.MsgParamSubPlan);
-            await _twitchAlertTypesService.HandleSubMysteryGiftAsync(gifter, count, tier);
+
+			if (count > 1)
+			{
+				_giftSubBundleSuppressionService.TrackBundle(gifter, count);
+			}
+
+			await _twitchAlertTypesService.HandleSubMysteryGiftAsync(gifter, count, tier);
         }
 
-        private async Task HandleOnRaidNotificationAsync(TwitchLib.Client.Events.OnRaidNotificationArgs e)
+        private async Task HandleOnRaidNotificationAsync(OnRaidNotificationArgs e)
         {
             var raiderDisplay = e.RaidNotification?.MsgParamDisplayName ?? AppSettings.Ads.DefaultUserName;
             var raiderUserId = e.RaidNotification?.UserId ?? string.Empty;

--- a/TwitchChatBot.Models/GiftSubBundleSuppressionState.cs
+++ b/TwitchChatBot.Models/GiftSubBundleSuppressionState.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TwitchChatBot.Models
+{
+	public class GiftSubBundleSuppressionState
+	{
+		public string GifterKey { get; set; } = string.Empty;
+
+		public int RemainingGiftCount { get; set; }
+
+		public DateTime ExpiresAtUtc { get; set; }
+	}
+}

--- a/TwitchChatBot.Tests/Core/TwitchClientWrapperTests.cs
+++ b/TwitchChatBot.Tests/Core/TwitchClientWrapperTests.cs
@@ -24,6 +24,7 @@ namespace TwitchChatBot.Tests.Core
 		private readonly Mock<IIRCNoticeService> _ircNoticeServiceMock = new();
 		private readonly Mock<ITwitchAlertTypesService> _twitchAlertTypesServiceMock = new();
 		private readonly Mock<IHelixLookupService> _helixLookupServiceMock = new();
+		private readonly Mock<IGiftSubBundleSuppressionService> _giftSubBundleSuppressionServiceMock = new();
 
 		private readonly TwitchClientWrapper _sut;
 
@@ -40,7 +41,8 @@ namespace TwitchChatBot.Tests.Core
 				_watchStreakServiceMock.Object,
 				_ircNoticeServiceMock.Object,
 				_twitchAlertTypesServiceMock.Object,
-				_helixLookupServiceMock.Object);
+				_helixLookupServiceMock.Object,
+				_giftSubBundleSuppressionServiceMock.Object);
 		}
 
 		// =========================
@@ -101,6 +103,52 @@ namespace TwitchChatBot.Tests.Core
 
 			var args = (OnMessageReceivedArgs)FormatterServices.GetUninitializedObject(typeof(OnMessageReceivedArgs));
 			SetAutoProperty(args, "ChatMessage", chatMessage);
+
+			return args;
+		}
+
+		private OnGiftedSubscriptionArgs GiftedSubscriptionArgs(
+			string gifter,
+			string recipient,
+			TwitchLib.Client.Enums.SubscriptionPlan plan = TwitchLib.Client.Enums.SubscriptionPlan.Tier1)
+		{
+			var giftedSubscription = FormatterServices.GetUninitializedObject(
+				typeof(GiftedSubscription));
+
+			SetAutoProperty(giftedSubscription, "DisplayName", gifter);
+			SetAutoProperty(giftedSubscription, "Login", gifter);
+			SetAutoProperty(giftedSubscription, "MsgParamRecipientUserName", recipient);
+			SetAutoProperty(giftedSubscription, "MsgParamSubPlan", plan);
+
+			var args = (OnGiftedSubscriptionArgs)FormatterServices.GetUninitializedObject(
+				typeof(OnGiftedSubscriptionArgs));
+
+			SetAutoProperty(args, "GiftedSubscription", giftedSubscription);
+
+			return args;
+		}
+
+		private OnCommunitySubscriptionArgs CommunitySubscriptionArgs(
+			string gifter,
+			int count,
+			TwitchLib.Client.Enums.SubscriptionPlan plan = TwitchLib.Client.Enums.SubscriptionPlan.Tier1)
+		{
+			var communitySubscription = FormatterServices.GetUninitializedObject(
+				typeof(CommunitySubscription));
+
+			SetAutoProperty(communitySubscription, "DisplayName", gifter);
+			SetAutoProperty(communitySubscription, "Login", gifter);
+			SetAutoProperty(communitySubscription, "MsgParamSubPlan", plan);
+
+			if (count > 0)
+			{
+				SetAutoProperty(communitySubscription, "MsgParamMassGiftCount", count);
+			}
+
+			var args = (OnCommunitySubscriptionArgs)FormatterServices.GetUninitializedObject(
+				typeof(OnCommunitySubscriptionArgs));
+
+			SetAutoProperty(args, "GiftedSubscription", communitySubscription);
 
 			return args;
 		}
@@ -239,6 +287,102 @@ namespace TwitchChatBot.Tests.Core
 			var result = _sut.GetGroupedViewers();
 
 			result.Should().NotContain(x => x.Username == "moduser");
+		}
+
+		[Fact]
+		public async Task HandleOnGiftedSubscriptionAsync_Should_SuppressIndividualGift_WhenSuppressionIsActive()
+		{
+			// Arrange
+			var args = GiftedSubscriptionArgs("GiftBoss", "ViewerOne");
+
+			_giftSubBundleSuppressionServiceMock
+				.Setup(x => x.ShouldSuppressIndividualGift("GiftBoss"))
+				.Returns(true);
+
+			// Act
+			await InvokePrivateAsync("HandleOnGiftedSubscriptionAsync", args);
+
+			// Assert
+			_giftSubBundleSuppressionServiceMock.Verify(
+				x => x.ShouldSuppressIndividualGift("GiftBoss"),
+				Times.Once);
+
+			_twitchAlertTypesServiceMock.Verify(
+				x => x.HandleSubGiftAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+				Times.Never);
+
+			_twitchAlertTypesServiceMock.Verify(
+				x => x.HandleSubMysteryGiftAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()),
+				Times.Never);
+		}
+
+		[Fact]
+		public async Task HandleOnGiftedSubscriptionAsync_Should_HandleSubGift_WhenSuppressionIsNotActive()
+		{
+			// Arrange
+			var args = GiftedSubscriptionArgs("GiftBoss", "ViewerOne");
+
+			_giftSubBundleSuppressionServiceMock
+				.Setup(x => x.ShouldSuppressIndividualGift("GiftBoss"))
+				.Returns(false);
+
+			// Act
+			await InvokePrivateAsync("HandleOnGiftedSubscriptionAsync", args);
+
+			// Assert
+			_giftSubBundleSuppressionServiceMock.Verify(
+				x => x.ShouldSuppressIndividualGift("GiftBoss"),
+				Times.Once);
+
+			_twitchAlertTypesServiceMock.Verify(
+				x => x.HandleSubGiftAsync("GiftBoss", "ViewerOne", "1000"),
+				Times.Once);
+
+			_twitchAlertTypesServiceMock.Verify(
+				x => x.HandleSubMysteryGiftAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()),
+				Times.Never);
+		}
+
+		[Fact]
+		public async Task HandleOnCommunitySubscriptionAsync_Should_TrackBundle_And_HandleMysteryGift()
+		{
+			// Arrange
+			var args = CommunitySubscriptionArgs("GiftBoss", 20);
+
+			// Act
+			await InvokePrivateAsync("HandleOnCommunitySubscriptionAsync", args);
+
+			// Assert
+			_giftSubBundleSuppressionServiceMock.Verify(
+				x => x.TrackBundle("GiftBoss", 20),
+				Times.Once);
+
+			_twitchAlertTypesServiceMock.Verify(
+				x => x.HandleSubMysteryGiftAsync("GiftBoss", 20, "1000"),
+				Times.Once);
+
+			_twitchAlertTypesServiceMock.Verify(
+				x => x.HandleSubGiftAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+				Times.Never);
+		}
+
+		[Fact]
+		public async Task HandleOnCommunitySubscriptionAsync_Should_DefaultCountToOne_WhenMassGiftCountIsZero()
+		{
+			// Arrange
+			var args = CommunitySubscriptionArgs("GiftBoss", 0);
+
+			// Act
+			await InvokePrivateAsync("HandleOnCommunitySubscriptionAsync", args);
+
+			// Assert
+			_giftSubBundleSuppressionServiceMock.Verify(
+				x => x.TrackBundle("GiftBoss", 1),
+				Times.Once);
+
+			_twitchAlertTypesServiceMock.Verify(
+				x => x.HandleSubMysteryGiftAsync("GiftBoss", 1, "1000"),
+				Times.Once);
 		}
 	}
 }

--- a/TwitchChatBot/Program.cs
+++ b/TwitchChatBot/Program.cs
@@ -97,6 +97,7 @@ namespace TwitchChatBot
 			services.TryAddSingleton<IChannelPointRedemptionStatusService, ChannelPointRedemptionStatusService>();
 			services.TryAddSingleton<IChannelPointRedemptionService, ChannelPointRedemptionService>();
 			services.AddSingleton<IChatMessageService, ChatMessageService>();
+			services.TryAddSingleton<IGiftSubBundleSuppressionService, GiftSubBundleSuppressionService>();
 
 			services.TryAddSingleton<IFirstChatterAlertService>(sp =>
             new FirstChatterAlertService(

--- a/TwitchChatBot/TwitchChatBot.UI.csproj
+++ b/TwitchChatBot/TwitchChatBot.UI.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<UseWindowsForms>true</UseWindowsForms>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>2.3.3</Version>
+		<Version>2.3.4</Version>
 		<RepositoryUrl>https://github.com/gmblogref/TwitchChatBot</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<ApplicationIcon>baseball_icon.ico</ApplicationIcon>


### PR DESCRIPTION
Summary:
This PR adds suppression handling for bulk/community gift subscription events so the bot only plays the mystery gift alert/TTS for gift bundles and suppresses the related individual gifted-sub alerts.

Changes:
- Added gift sub bundle suppression tracking.
- Moved gift-sub suppression handling into TwitchClientWrapper, where subscription events are currently handled.
- Removed gift-sub suppression dependency from EventSubSocketService since subscription events are no longer subscribed through EventSub there.
- Community/bulk gift subscriptions now track the expected gift count.
- Individual gifted-sub events from the same gifter are suppressed while the bundle suppression is active.
- Normal single gifted subs still trigger the standard SubGift alert/TTS.
- Added TwitchClientWrapper tests for:
  - Suppressing individual gifted subs when suppression is active
  - Allowing normal gifted subs when suppression is not active
  - Tracking community gift bundles
  - Defaulting community gift count safely
  - Existing viewer/chat handling coverage

Validation:
- All tests pass.
- Ready for live Twitch validation during the next stream.

Notes:
- Hype Train alerts remain separate and are not suppressed by this change.
- Suppression applies to gift bundles greater than one and clears when the expected count is reached, the time window expires, or the bot resets.